### PR TITLE
Dev

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,6 +1,28 @@
-## CHANGELOG
+# CHANGELOG
 
 <br/>
+<br/>
+
+<details>
+<summary>
+
+## ALL VERSIONS
+
+</summary>
+
+<details>
+<summary>
+
+### **Version [0.0.2] -->** _2025/07/22 23:20_
+
+</summary>
+
+- 🐛 **Fix**: Ensure `data` is always defined in function-based permissions
+  checks
+- 🐛 **Fix**: Correct type inference for `data` in permission functions
+- Add inspiration
+</details>
+
 <br/>
 
 <details>
@@ -30,6 +52,8 @@
 
 </details>
 
+</details>
+
 #### **Features :**
 
 - Multi-role user support with permission inheritance
@@ -41,16 +65,25 @@
 
 <br/>
 
+[Web Dev Simplified](https://www.youtube.com/@WebDevSimplified)
+
+The Youtube video that inspired this library can be found
+[here](https://www.youtube.com/watch?v=5GG-VUvruzE).
+
 ## Author
 
-chlbri (bri_lvi@icloud.com)
+**chlbri** (bri_lvi@icloud.com)
 
-[My github](https://github.com/chlbri?tab=repositories)
-
-[<svg width="98" height="96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>](https://github.com/chlbri?tab=repositories)
-
-<br/>
+[<img src="https://github.com/chlbri.png" width="50" height="50" style="border-radius: 50%;">](https://github.com/chlbri?tab=repositories)
+[GitHub Profile](https://github.com/chlbri?tab=repositories)
 
 ## Links
 
-- [Documentation](https://github.com/chlbri/new-package)
+- [NPM Package](https://www.npmjs.com/package/@bemedev/permissions)
+- [GitHub Repository](https://github.com/chlbri/permissions)
+- [Documentation](https://github.com/chlbri/permissions#readme)
+- [Issues](https://github.com/chlbri/permissions/issues)
+
+---
+
+Made with ❤️ by [bemedev](https://bemedev.vercel.app)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bemedev/permissions",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A library for managing permissions",
   "author": {
     "email": "bri_lvi@icloud.com",
@@ -83,8 +83,10 @@
     }
   ],
   "devDependencies": {
+    "@bemedev/decompose": "^0.9.0",
     "@bemedev/fsf": "^0.8.0",
     "@bemedev/rollup-config": "^0.1.1",
+    "@bemedev/types": "^0.3.1",
     "@bemedev/vitest-alias": "^0.0.3",
     "@bemedev/vitest-exclude": "^0.1.1",
     "@bemedev/vitest-extended": "^1.3.6",
@@ -112,5 +114,9 @@
     "onlyBuiltDependencies": [
       "esbuild"
     ]
+  },
+  "peerDependencies": {
+    "@bemedev/decompose": "^0.9.0",
+    "@bemedev/types": "^0.3.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,18 @@ settings:
 importers:
   .:
     devDependencies:
+      '@bemedev/decompose':
+        specifier: ^0.9.0
+        version: 0.9.0(@bemedev/types@0.3.1)
       '@bemedev/fsf':
         specifier: ^0.8.0
         version: 0.8.0
       '@bemedev/rollup-config':
         specifier: ^0.1.1
         version: 0.1.1(glob@11.0.3)(rollup@4.45.1)(typescript@5.8.3)
+      '@bemedev/types':
+        specifier: ^0.3.1
+        version: 0.3.1
       '@bemedev/vitest-alias':
         specifier: ^0.0.3
         version: 0.0.3(vitest@3.2.4(@types/node@24.1.0)(jiti@2.4.2))
@@ -124,6 +130,15 @@ packages:
       }
     engines: { node: '>=18' }
 
+  '@bemedev/decompose@0.9.0':
+    resolution:
+      {
+        integrity: sha512-LFCK6cuoyXmyWdd8kUtQwy5CTAUwVCowdUMnto4hpWBtDQO9Kq1QDqMEMOuZNxkTgNxHWt5Lacqvn8MRekqgsw==,
+      }
+    engines: { node: '>=20' }
+    peerDependencies:
+      '@bemedev/types': ^0.1.8
+
   '@bemedev/fsf@0.8.0':
     resolution:
       {
@@ -151,6 +166,13 @@ packages:
     resolution:
       {
         integrity: sha512-deiw1HTCJzF9vEsRI6AhGwi/7RafYjufPCjoY4qReoy60bduHaheEzVv853P8iJIbRiRpMBUXro9chweI/XrGA==,
+      }
+    engines: { node: '>=22' }
+
+  '@bemedev/types@0.3.1':
+    resolution:
+      {
+        integrity: sha512-kfmHwkRzaMAqEUpzYutPxcwaXWAbZEKQ9LlNkRSv4ABvDuxSndc3gKg8PCeoEP49DviB9uU5KK11vEfUAB7Spg==,
       }
     engines: { node: '>=22' }
 
@@ -2386,6 +2408,13 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-deepmerge@7.0.3:
+    resolution:
+      {
+        integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==,
+      }
+    engines: { node: '>=14.13.1' }
+
   tsc-alias@1.8.16:
     resolution:
       {
@@ -2589,6 +2618,11 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@bemedev/decompose@0.9.0(@bemedev/types@0.3.1)':
+    dependencies:
+      '@bemedev/types': 0.3.1
+      ts-deepmerge: 7.0.3
+
   '@bemedev/fsf@0.8.0':
     dependencies:
       '@bemedev/x-guard': 0.2.0
@@ -2609,6 +2643,8 @@ snapshots:
   '@bemedev/sleep@0.1.2': {}
 
   '@bemedev/types@0.1.9': {}
+
+  '@bemedev/types@0.3.1': {}
 
   '@bemedev/vitest-alias@0.0.3(vitest@3.2.4(@types/node@24.1.0)(jiti@2.4.2))':
     dependencies:
@@ -3850,6 +3886,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  ts-deepmerge@7.0.3: {}
 
   tsc-alias@1.8.16:
     dependencies:

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -42,6 +42,35 @@ export const types = {
     } satisfies PermissionsType<A>;
   },
 
+  object: <T extends object>(obj?: T) => identity<T>(obj),
+
+  partial: <T extends object>(objt?: T) => {
+    return identity<Partial<T>>(objt);
+  },
+
+  omit: <T extends object, K extends (keyof T)[]>(..._: K) => {
+    return identity<Omit<T, K[number]>>();
+  },
+
+  omit2: <T extends object, K extends (keyof T)[]>(
+    _obj: T,
+    ..._keys: K
+  ) => {
+    return types.omit<T, K>(..._keys);
+  },
+
+  string: identity<string>(),
+
+  number: identity<number>(),
+
+  boolean: identity<boolean>(),
+
+  date: identity<Date>(),
+
+  array: <T>(...items: T[]) => identity<T[]>(items),
+
+  tuple: <T extends readonly any[]>(...items: T) => identity(items),
+
   permissions: <
     P extends Record<string, { dataType: any; actions: string[] }>,
   >(

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
+import { transform } from '@bemedev/types';
+import type {
+  MapS,
+  ObjectS,
+  PartialCustom,
+  TransformO,
+} from '@bemedev/types/lib/transform/types.types';
 import type {
   PermissionsType,
   PermissionsTypes,
@@ -11,10 +18,10 @@ import type {
 type AnyArray<T> = T[] | readonly T[];
 
 type TransformPermissions<
-  P extends Record<string, { dataType: any; actions: string[] }>,
+  P extends Record<string, { dataType: ObjectS; actions: string[] }>,
 > = {
   [K in keyof P]: {
-    dataType: P[K]['dataType'];
+    dataType: TransformO<P[K]['dataType']>;
     action: P[K]['actions'][number];
   };
 };
@@ -24,63 +31,43 @@ export const identity = <const T>(value?: T) => value as T;
 export const types = {
   roles: <const R extends AnyArray<Roles>>(...roles: R) => identity(roles),
 
-  user: <const R extends AnyArray<Roles>, Rest = any>(
+  user: <
+    const R extends AnyArray<Roles>,
+    const Rest extends MapS | PartialCustom = MapS | PartialCustom,
+  >(
     __?: Rest,
     ..._: R
-  ) => identity<Omit<Rest, '__id' | 'roles'> & User<R[number]>>(),
+  ) => {
+    const rest = transform(__);
+    return identity<
+      Readonly<Omit<typeof rest, '__id' | 'roles'> & User<R[number]>>
+    >();
+  },
 
-  permission: <const S extends string[], const A = any>(
+  permission: <
+    const S extends string[],
+    const A extends ObjectS = ObjectS,
+  >(
     dataType?: A,
     ...actions: S
   ) => {
-    return {
-      dataType,
+    return identity<PermissionsType<TransformO<A>>>({
+      dataType: identity<TransformO<A>>((transform as any)(dataType)),
       action: actions[0],
-    } as {
-      action: S[number];
-      dataType: A;
-    } satisfies PermissionsType<A>;
+    });
   },
-
-  object: <T extends object>(obj?: T) => identity<T>(obj),
-
-  partial: <T extends object>(objt?: T) => {
-    return identity<Partial<T>>(objt);
-  },
-
-  omit: <T extends object, K extends (keyof T)[]>(..._: K) => {
-    return identity<Omit<T, K[number]>>();
-  },
-
-  omit2: <T extends object, K extends (keyof T)[]>(
-    _obj: T,
-    ..._keys: K
-  ) => {
-    return types.omit<T, K>(..._keys);
-  },
-
-  string: identity<string>(),
-
-  number: identity<number>(),
-
-  boolean: identity<boolean>(),
-
-  date: identity<Date>(),
-
-  array: <T>(...items: T[]) => identity<T[]>(items),
-
-  tuple: <T extends readonly any[]>(...items: T) => identity(items),
 
   permissions: <
-    P extends Record<string, { dataType: any; actions: string[] }>,
+    P extends Record<string, { dataType: ObjectS; actions: string[] }>,
   >(
     permissions: P,
   ) => {
     const entries = Object.entries(permissions);
 
     return entries
-      .map(([key, { actions, dataType }]) => {
+      .map(([key, { actions, dataType: dt }]) => {
         const action = actions[0];
+        const dataType = transform(dt);
         return [key, { dataType, action }] as const;
       })
       .reduce(
@@ -91,8 +78,11 @@ export const types = {
 
   rolesWithPermissions: <
     const R extends AnyArray<Roles>,
-    P extends Record<string, { dataType: any; actions: string[] }>,
-    Rest = any,
+    const P extends Record<
+      string,
+      { dataType: ObjectS; actions: string[] }
+    >,
+    const Rest extends MapS | PartialCustom = MapS | PartialCustom,
   >(
     _permissions: P,
     _restUser?: Rest,
@@ -111,8 +101,11 @@ export const types = {
 
   args: <
     const R extends AnyArray<Roles>,
-    P extends Record<string, { dataType: any; actions: string[] }>,
-    Rest = any,
+    const P extends Record<
+      string,
+      { dataType: ObjectS; actions: string[] }
+    >,
+    const Rest extends MapS | PartialCustom = MapS | PartialCustom,
   >(
     _permissions: P,
     _restUser?: Rest,
@@ -131,9 +124,9 @@ type CreateRolesWithPermissionsArgs<
 };
 
 export const createRolesWithPermissions = <
-  R extends Roles[],
-  U extends User<R[number]>,
-  P extends PermissionsTypes,
+  const R extends Roles[],
+  const U extends User<R[number]>,
+  const P extends PermissionsTypes,
 >(
   _?: CreateRolesWithPermissionsArgs<R, U, P>,
 ) => {
@@ -147,7 +140,7 @@ export const createRolesWithPermissions = <
       owner: U;
       resource: Re;
       action: P[Re]['action'];
-      data?: P[Re]['dataType'];
+      data?: Partial<P[Re]['dataType']>;
     };
 
     const hasPermissions = <Re extends Extract<keyof P, string>>({
@@ -162,14 +155,18 @@ export const createRolesWithPermissions = <
 
         if (typeof permission === 'function') {
           return (
-            data != null &&
-            permission({
-              performer,
-              data,
-              owner,
-            })
+            !!data &&
+            permission(
+              Object.freeze({
+                performer,
+                data,
+                owner,
+              }),
+            )
           );
         }
+
+        if (!permission) return false;
 
         return permission;
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { KeysMatching } from '@bemedev/decompose';
+
 export type DeepPartial<T extends object> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };
@@ -18,14 +20,15 @@ export type PermissionCheck<
   P extends PermissionsTypes,
   K extends keyof P,
   PD extends P[K]['dataType'] = P[K]['dataType'],
+  Keys = KeysMatching<PD>[],
 > =
   | boolean
-  | PD
+  | Keys
   | ((args: {
       performer: U;
       data: P[K]['dataType'];
       owner: U;
-    }) => boolean | PD);
+    }) => boolean | Keys);
 
 export type RolesWithPermissions<
   R extends Roles,


### PR DESCRIPTION
- Updated the permissions functions to improve type safety and clarity.
- Replaced `types.omit2` with direct object definitions for `comments` and `todos` data types.
- Added a new action 'remove' for comments permissions.
- Refactored the `permission` type to utilize `TransformO` for better type inference.
- Improved the handling of blocked users in permission checks.
- Introduced `KeysMatching` for more precise type checks in permission validation.
- Added debug tests to log roles and permissions structure.

NEW_VERSION